### PR TITLE
Fixed incorrect createdAt key

### DIFF
--- a/src/entriesGateway.ts
+++ b/src/entriesGateway.ts
@@ -14,13 +14,15 @@ export class EntriesGateway {
   async fetch(): Promise<EntryValue[]> {
     const entries: EntryCollection<EntryPlainObject> = await this._client.getEntries();
     const r = entries.items.map(item => {
-      const content = marked(item.fields.content);
-      const createdAt = unwrapOrFromUndefinable(item.fields.publishedAt, item.fields.createdAt);
-      const excerpt = createExcerptText(item.fields);
+      const { sys, fields } = item;
+
+      const content = marked(fields.content);
+      const createdAt = unwrapOrFromUndefinable(fields.publishedAt, sys.createdAt);
+      const excerpt = createExcerptText(fields);
 
       const o = {
-        ...item.sys,
-        ...item.fields,
+        ...sys,
+        ...fields,
         content,
         createdAt,
         excerpt,


### PR DESCRIPTION
Fixed error in entriesGateway.

```
(node:11420) UnhandledPromiseRejectionWarning: Error: TypeError: `def` must not be `undefined`
    at C:\Users\ta2\src\github.com\kubosho\blog\dist\server.js:28:19
    at Generator.throw (<anonymous>)
    at rejected (C:\Users\ta2\src\github.com\kubosho\blog\dist\server.js:5:65)
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
(node:11420) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:11420) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```